### PR TITLE
Address Github set-output deprecation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,4 @@ results="${results//'"'/''}"
 results="${results//'%'/'%25'}"
 results="${results//$'\n'/'%0A'}"
 results="${results//$'\r'/'%0D'}"
-echo "::set-output name=results::$results"
+echo "results=$result" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
When I use this action for static code analysis, I receive the following deprecation warning: 

 Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

According to the article, `set-output` commands will fail with an error starting the first of June. 